### PR TITLE
Permission added for groups

### DIFF
--- a/amplify/backend/storage/blogimages/cli-inputs.json
+++ b/amplify/backend/storage/blogimages/cli-inputs.json
@@ -11,5 +11,5 @@
     "READ",
     "DELETE"
   ],
-  "triggerFunction": "NONE"
+  "groupAccess": {}
 }


### PR DESCRIPTION
This small change is required to test if we can provide permission by groups.

At the moment we can only upload if the user is authenticated by cognito, but not using google creds.

Since google users belong to group admins, we would like to test if the upload script will work with this change