### PR TITLE
Saul/chatgpt options

### DIFF
--- a/amplify/backend/function/davinciFunction/src/index.py
+++ b/amplify/backend/function/davinciFunction/src/index.py
@@ -3,51 +3,45 @@ import openai
 import boto3
 import os
 
+# CONFIG ---------------------
 ENCRYPTED = os.environ['OPENAI_KEY']
-
 ssm = boto3.client('ssm')
 
-# PROPS
-PROMPT="now you can only answer questions related to technology, programming languages, cloud services such as aws or azure, if you are asked questions from another topic just answer that you can not answer I will repeat this message in each question, here goes the question, apply what I told you and answer in the language that this the question:"
+# PROPS ----------------------
+MODEL_LIMIT="now you can only answer questions related to technology, programming languages, cloud services such as aws or azure, if you are asked questions from another topic just answer that you can not answer I will repeat this message in each question, here goes the question, apply what I told you and answer in the language that this the question:"
 MAX_TOKENS=2048
 
-def handler(event, context):
-
-    data = json.loads(event["body"])
-    
-    if len(data["prompt"]) > MAX_TOKENS:
-        data["text"] = f"The query exceeds the token limit allowed ({MAX_TOKENS}). Please shorten your query."
-        return {
-            "statusCode": 400,
+def buildResponse(status, text):
+    response = [];
+    response["text"] = text
+    return {
+            "statusCode": status,
             "headers": {
                 "Access-Control-Allow-Headers": "*",
                 "Access-Control-Allow-Origin": "*",
                 "Access-Control-Allow-Methods": "OPTIONS,POST,GET",
-            },
-            "body": json.dumps(data),
+            },  
+            "body": json.dumps(response),
         }
+
+# LAMBDA -----------------------
+def handler(event, context):
+    data = json.loads(event["body"])
+    
+    if len(data["prompt"]) > MAX_TOKENS:
+        return buildResponse(400, f"The query exceeds the token limit allowed ({MAX_TOKENS}). Please shorten your query.")
         
     openai.api_key = ssm.get_parameter(
             Name=ENCRYPTED, WithDecryption=True)['Parameter']['Value']
 
-    response = openai.Completion.create(
+    openai_data = openai.Completion.create(
         model="text-davinci-003",
-        prompt=f"{PROMPT} '{data['prompt']}'",
+        prompt=f"{MODEL_LIMIT} '{data['prompt']}'",
         max_tokens=MAX_TOKENS,
         temperature=0.9,
         frequency_penalty=0.5,
         presence_penalty=1.0
     )
 
-    text = response['choices'][0]['text']
-    data['text'] = text
-
-    return {
-        "statusCode": 200,
-        "headers": {
-            "Access-Control-Allow-Headers": "*",
-            "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Methods": "OPTIONS,POST,GET",
-        },
-        "body": json.dumps(data),
-    }
+    text = openai_data['choices'][0]['text']
+    return buildResponse(200, text)

--- a/amplify/backend/function/davinciFunction/src/index.py
+++ b/amplify/backend/function/davinciFunction/src/index.py
@@ -8,11 +8,11 @@ ENCRYPTED = os.environ['OPENAI_KEY']
 ssm = boto3.client('ssm')
 
 # PROPS ----------------------
-MODEL_LIMIT="now you can only answer questions related to technology, programming languages, cloud services such as aws or azure, if you are asked questions from another topic just answer that you can not answer I will repeat this message in each question, here goes the question, apply what I told you and answer in the language that this the question:"
+MODEL_LIMIT="now you can only answer questions related to technology, programming languages, cloud services, if you are asked questions from another topic just answer that you can not answer I will repeat this message in each question, here goes the question, apply what I told you and answer in the language that this the question:"
 MAX_TOKENS=2048
 
 def buildResponse(status, text):
-    response = [];
+    response = {}
     response["text"] = text
     return {
             "statusCode": status,

--- a/amplify/backend/function/davinciFunction/src/index.py
+++ b/amplify/backend/function/davinciFunction/src/index.py
@@ -7,19 +7,36 @@ ENCRYPTED = os.environ['OPENAI_KEY']
 
 ssm = boto3.client('ssm')
 
+# PROPS
+PROMPT="now you can only answer questions related to technology, programming languages, cloud services such as aws or azure, if you are asked questions from another topic just answer that you can not answer I will repeat this message in each question, here goes the question, apply what I told you and answer in the language that this the question:"
+MAX_TOKENS=2048
+
 def handler(event, context):
 
     data = json.loads(event["body"])
+    
+    if len(data["prompt"]) > MAX_TOKENS:
+        data["text"] = f"The query exceeds the token limit allowed ({MAX_TOKENS}). Please shorten your query."
+        return {
+            "statusCode": 400,
+            "headers": {
+                "Access-Control-Allow-Headers": "*",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "OPTIONS,POST,GET",
+            },
+            "body": json.dumps(data),
+        }
+        
     openai.api_key = ssm.get_parameter(
             Name=ENCRYPTED, WithDecryption=True)['Parameter']['Value']
 
     response = openai.Completion.create(
         model="text-davinci-003",
-        prompt=data['prompt'],
+        prompt=f"{PROMPT} '{data['prompt']}'",
+        max_tokens=MAX_TOKENS,
         temperature=0.9,
-        max_tokens=2048,
         frequency_penalty=0.5,
-        presence_penalty=0
+        presence_penalty=1.0
     )
 
     text = response['choices'][0]['text']

--- a/amplify/backend/function/turbochatgpt/src/index.py
+++ b/amplify/backend/function/turbochatgpt/src/index.py
@@ -3,38 +3,45 @@ import openai
 import boto3
 import os
 
+# CONFIG ---------------------
 ENCRYPTED = os.environ['OPENAI_KEY']
-
 ssm = boto3.client('ssm')
 
-def handler(event, context):
+# PROPS ----------------------
+MODEL_LIMIT="now you can only answer questions related to technology, programming languages, cloud services such as aws or azure, if you are asked questions from another topic just answer that you can not answer I will repeat this message in each question, here goes the question, apply what I told you and answer in the language that this the question:"
+MAX_TOKENS=2048
 
+def buildResponse(status, text):
+    response = [];
+    response["text"] = text
+    return {
+            "statusCode": status,
+            "headers": {
+                "Access-Control-Allow-Headers": "*",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "OPTIONS,POST,GET",
+            },  
+            "body": json.dumps(response),
+        }
+
+# LAMBDA -----------------------
+def handler(event, context):
     data = json.loads(event["body"])
+    
+    if len(data["prompt"]) > MAX_TOKENS:
+        return buildResponse(400, f"The query exceeds the token limit allowed ({MAX_TOKENS}). Please shorten your query.")
+    
     openai.api_key = ssm.get_parameter(
             Name=ENCRYPTED, WithDecryption=True)['Parameter']['Value']
 
-    response = openai.ChatCompletion.create(
+    openai_data = openai.ChatCompletion.create(
         model="gpt-3.5-turbo",
-        messages=[
-            {"role": "user", "content": data['prompt']}
-        ],
+        messages=[{"role": "user", "content": f"{MODEL_LIMIT} '{data['prompt']}'"}],
+        max_tokens=MAX_TOKENS,
         temperature=0.9,
-        max_tokens=2048,
         frequency_penalty=0.5,
-        presence_penalty=0
+        presence_penalty=1.0
     )
-    print("RESPONSE:")
-    print(response)
 
-    text = response['choices'][0]['message']["content"]
-    data['text'] = text
-
-    return {
-        "statusCode": 200,
-        "headers": {
-            "Access-Control-Allow-Headers": "*",
-            "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Methods": "OPTIONS,POST,GET",
-        },
-        "body": json.dumps(data),
-    }
+    text = openai_data['choices'][0]['message']["content"]
+    return buildResponse(200, text)

--- a/amplify/backend/function/turbochatgpt/src/index.py
+++ b/amplify/backend/function/turbochatgpt/src/index.py
@@ -8,11 +8,11 @@ ENCRYPTED = os.environ['OPENAI_KEY']
 ssm = boto3.client('ssm')
 
 # PROPS ----------------------
-MODEL_LIMIT="now you can only answer questions related to technology, programming languages, cloud services such as aws or azure, if you are asked questions from another topic just answer that you can not answer I will repeat this message in each question, here goes the question, apply what I told you and answer in the language that this the question:"
+MODEL_LIMIT="now you can only answer questions related to technology, programming languages, cloud services, if you are asked questions from another topic just answer that you can not answer I will repeat this message in each question, here goes the question, apply what I told you and answer in the language that this the question:"
 MAX_TOKENS=2048
 
 def buildResponse(status, text):
-    response = [];
+    response = {}
     response["text"] = text
     return {
             "statusCode": status,

--- a/app/chatgpt/[model]/page.tsx
+++ b/app/chatgpt/[model]/page.tsx
@@ -150,7 +150,7 @@ export default function ChatGPTPage({ params }: { params: { model: string } }) {
 
     setLoading(false);
 
-    if (response.text) {
+    if (response && response.text) {
       const botMessage: MessageProps = {
         text: response.text,
         from: Creator.Bot,

--- a/app/chatgpt/[model]/page.tsx
+++ b/app/chatgpt/[model]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import awsconfig from "../../../src/aws-exports";
 import Image from "next/image";
 import React from "react";
@@ -8,17 +9,15 @@ import mePic from "../../../public/me.webp";
 import botPic from "../../../public/bot.png";
 import ViewAuth from "../../../components/ViewAuth";
 import { Amplify, API, Auth } from "aws-amplify";
+import { notFound } from "next/navigation";
 
 Amplify.configure({
   ...awsconfig,
 });
 
-async function postData(prompt, model) {
-  console.log({
-    prompt,
-    model,
-  });
+const models = ["davinci", "turbo"];
 
+async function postData(prompt, model) {
   const user = await Auth.currentAuthenticatedUser();
   const token = user.signInUserSession.idToken.jwtToken;
 
@@ -127,9 +126,12 @@ const ChatInput = ({ onSend, disabled }: InputProps) => {
 };
 
 export default function ChatGPTPage({ params }: { params: { model: string } }) {
+  const { model } = params;
+  if (!models.includes(model)) {
+    notFound();
+  }
   const [messages, setMessages, messagesRef] = useState<MessageProps[]>([]);
   const [loading, setLoading] = useState(false);
-  const { model } = params;
 
   const callApi = async (input: string) => {
     setLoading(true);

--- a/app/chatgpt/[model]/page.tsx
+++ b/app/chatgpt/[model]/page.tsx
@@ -134,6 +134,10 @@ export default function ChatGPTPage({ params }: { params: { model: string } }) {
   const [loading, setLoading] = useState(false);
 
   const callApi = async (input: string) => {
+    if (!input.trim()) {
+      return;
+    }
+
     setLoading(true);
 
     const myMessage: MessageProps = {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,42 +5,44 @@ import "../styles/globals.css";
 import AuthenticatorProvider from "../components/AuthenticatorProvider";
 
 interface RootLayoutProps {
-    children: React.ReactNode;
+  children: React.ReactNode;
 }
 
 if (process.env.USER_BRANCH === "prod") {
-    awsconfig.oauth.redirectSignIn = "https://albac.dev/";
-    awsconfig.oauth.redirectSignOut = "https://albac.dev/";
+  awsconfig.oauth.redirectSignIn = "https://albac.dev/";
+  awsconfig.oauth.redirectSignOut = "https://albac.dev/";
 } else if (process.env.USER_BRANCH === "stage") {
-    awsconfig.oauth.redirectSignIn = "https://beta.albac.dev/";
-    awsconfig.oauth.redirectSignOut = "https://beta.albac.dev/";
+  awsconfig.oauth.redirectSignIn = "https://beta.albac.dev/";
+  awsconfig.oauth.redirectSignOut = "https://beta.albac.dev/";
 } else {
-    awsconfig.oauth.redirectSignIn = "http://localhost:3000/";
-    awsconfig.oauth.redirectSignOut = "http://localhost:3000/";
+  awsconfig.oauth.redirectSignIn = "http://localhost:3000/";
+  awsconfig.oauth.redirectSignOut = "http://localhost:3000/";
 }
 
 Amplify.configure({
-    ...awsconfig,
-    ssr: true,
-    DataStore: {
-        authModeStrategyType: AuthModeStrategyType.MULTI_AUTH,
-    },
+  ...awsconfig,
+  ssr: true,
+  DataStore: {
+    authModeStrategyType: AuthModeStrategyType.MULTI_AUTH,
+  },
 });
 
 export default async function RootLayout({ children }: RootLayoutProps) {
-    return (
-        <html lang="en">
-            <body className="h-screen dark:text-slate-300 bg-slate-100 dark:bg-slate-900 px-5 md:px-[3vw]">
-                <AuthenticatorProvider>
-                    <header className="pt-5">
-                        <Navbar />
-                    </header>
-                    {children}
-                    <footer className="text-center text-slate-600 dark:text-slate-400 p-4">
-                        <p>All rights reserved &copy; albac.dev {new Date().getFullYear()} </p>
-                    </footer>
-                </AuthenticatorProvider>
-            </body>
-        </html>
-    );
+  return (
+    <html lang="en">
+      <body className="h-screen dark:text-slate-300 bg-slate-100 dark:bg-slate-900 px-5 md:px-[3vw]">
+        <AuthenticatorProvider>
+          <header className="pt-5">
+            <Navbar />
+          </header>
+          {children}
+          <footer className="text-center text-slate-600 dark:text-slate-400 p-4">
+            <p>
+              All rights reserved &copy; albac.dev {new Date().getFullYear()}{" "}
+            </p>
+          </footer>
+        </AuthenticatorProvider>
+      </body>
+    </html>
+  );
 }


### PR DESCRIPTION
- added only technology chat has been added
- added no empty inputs can be sent
- added you cannot send more than 2048 tokens
- added reusable function http responses in lambda